### PR TITLE
Also include packages from inherited Koji tags.

### DIFF
--- a/eln-tag-sync.py
+++ b/eln-tag-sync.py
@@ -13,7 +13,7 @@ session.gssapi_login(keytab=os.getenv('KOJI_KEYTAB'))
 
 
 def get_builds(tag):
-    return session.listTagged(tag, latest=True)
+    return session.listTagged(tag, latest=True, inherit=True)
 
 
 def tag_build(tag, nvr):

--- a/eln-tag-sync.py
+++ b/eln-tag-sync.py
@@ -12,8 +12,8 @@ session = koji.ClientSession('https://koji.fedoraproject.org/kojihub')
 session.gssapi_login(keytab=os.getenv('KOJI_KEYTAB'))
 
 
-def get_builds(tag):
-    return session.listTagged(tag, latest=True, inherit=True)
+def get_builds(tag, inherit=False):
+    return session.listTagged(tag, latest=True, inherit=inherit)
 
 
 def tag_build(tag, nvr):
@@ -117,7 +117,7 @@ if __name__ == "__main__":
 
     wanted_packages = get_wanted_packages()
 
-    source_builds = get_builds(args.srctag)
+    source_builds = get_builds(args.srctag, inherit=True)
     dest_builds = get_builds(args.desttag)
     dest_nvrs = [x['nvr'] for x in dest_builds]
 


### PR DESCRIPTION
We want to switch tags from `f34` to `f34-updates`. The `f34-updates` tag contains only updated Koji builds and inherits Koji builds from original release using the `f34` tag. We want to consider both and therefore we need to enable inheritance when asking for Koji builds.