### PR TITLE
Use f34-updates tag instead of of f34.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     parameters {
         string(
             name: 'SOURCE_TAG',
-            defaultValue: 'f34',
+            defaultValue: 'f34-updates',
             trim: true,
             description: 'Source tag.'
         )


### PR DESCRIPTION
We want to switch tags from f34 to f34-updates. The f34-updates tag contains only updated Koji builds and inherits Koji builds from original release using the f34 tag. We want to consider both.